### PR TITLE
Rebuild for new compilers (again)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: b6d6ebeea146e09fc7aef827a3a3b22b7af674c2f0c67169c2275237e54c0c02
 
 build:
-  number: 1002
+  number: 2002
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Due to an issue in ci-scripts, which has been resolved, there was a bad version
number bump in the main channel for this package.

This PR will increase the build number for the new compiler's build by 1000,
allowing them to take precedence when the new compilers are merged with the
main branch.